### PR TITLE
Set canBecomeKey to false on PassThroughWindow

### DIFF
--- a/Sources/StreamDeckSimulator/StreamDeckSimulator.swift
+++ b/Sources/StreamDeckSimulator/StreamDeckSimulator.swift
@@ -55,6 +55,7 @@ public final class StreamDeckSimulator {
     }
 
     private class PassThroughWindow: UIWindow {
+        override var canBecomeKey: Bool { false }
 
         override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
             // Get view from superclass.


### PR DESCRIPTION
It's pretty common for apps to use `UIWindowScene.keyWindow` in order to get the view hierarchy from somewhere. When the stream deck simulator is shown, however, it becomes the key window. This was breaking some functionality in our app, as the stream deck window was returned instead of our main window.

Setting this to false should have no impact on functionality.