### PR TITLE
Fixing an issue with memory management

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -29,12 +29,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Simulator
-        run: set -o pipefail && xcodebuild -scheme StreamDeckSimulator -destination "platform=iOS Simulator,name=iPad Air (5th generation),OS=latest" -skipMacroValidation | xcpretty
+        run: set -o pipefail && xcodebuild -scheme StreamDeckSimulator -destination "platform=iOS Simulator,name=iPad (10th generation),OS=latest" -skipMacroValidation | xcpretty
 
       - name: Build Example 
         run: |
           cd Example
-          set -o pipefail && xcodebuild -scheme "StreamDeckKitExample App" -destination "platform=iOS Simulator,name=iPad Air (5th generation),OS=latest" -skipMacroValidation | xcpretty
+          set -o pipefail && xcodebuild -scheme "StreamDeckKitExample App" -destination "platform=iOS Simulator,name=iPad (10th generation),OS=latest" -skipMacroValidation | xcpretty
 
   test:
     name: Run unit tests

--- a/Sources/StreamDeckKit/Device/StreamDeckClient.swift
+++ b/Sources/StreamDeckKit/Device/StreamDeckClient.swift
@@ -63,12 +63,16 @@ final class StreamDeckClient {
             case SDInputEventType_Rotary.rawValue:
                 switch UInt32(event.rotaryEncoders.type) {
                 case SDInputEventRotaryType_Rotate.rawValue:
-                    let rotationValues = withUnsafeBytes(of: &event.rotaryEncoders.rotate) { rawPtr in
-                        Array(rawPtr.bindMemory(to: Int8.self))
-                    }
+                    let encoderCount = Int(event.rotaryEncoders.encoderCount)
+                    withUnsafeBytes(of: &event.rotaryEncoders.rotate) { rawPtr in
+                        let buffer = rawPtr.baseAddress!.assumingMemoryBound(to: Int8.self)
 
-                    for (index, value) in rotationValues.enumerated() where value != 0 {
-                        inputEventHandler?(.rotaryEncoderRotation(index: index, rotation: Int(value)))
+                        for encoder in 0 ..< encoderCount {
+                            let value = buffer.advanced(by: encoder).pointee
+                            if value != 0 {
+                                inputEventHandler?(.rotaryEncoderRotation(index: encoder, rotation: Int(value)))
+                            }
+                        }
                     }
                 case SDInputEventRotaryType_Press.rawValue:
                     let current = event.rotaryEncoders.press

--- a/Sources/StreamDeckKit/Device/StreamDeckClient.swift
+++ b/Sources/StreamDeckKit/Device/StreamDeckClient.swift
@@ -63,15 +63,12 @@ final class StreamDeckClient {
             case SDInputEventType_Rotary.rawValue:
                 switch UInt32(event.rotaryEncoders.type) {
                 case SDInputEventRotaryType_Rotate.rawValue:
-                    let buffer = withUnsafeBytes(of: &event.rotaryEncoders.rotate) { rawPtr in
-                        rawPtr.baseAddress!.assumingMemoryBound(to: Int8.self)
+                    let rotationValues = withUnsafeBytes(of: &event.rotaryEncoders.rotate) { rawPtr in
+                        Array(rawPtr.bindMemory(to: Int8.self))
                     }
 
-                    for encoder in 0 ..< Int(event.rotaryEncoders.encoderCount) {
-                        let value = buffer.advanced(by: encoder).pointee
-                        if value != 0 {
-                            inputEventHandler?(.rotaryEncoderRotation(index: encoder, rotation: Int(value)))
-                        }
+                    for (index, value) in rotationValues.enumerated() where value != 0 {
+                        inputEventHandler?(.rotaryEncoderRotation(index: index, rotation: Int(value)))
                     }
                 case SDInputEventRotaryType_Press.rawValue:
                     let current = event.rotaryEncoders.press


### PR DESCRIPTION
## Problem:

The code was capturing a raw pointer returned from withUnsafeBytes(of:) and using it outside the closure. This caused undefined behavior because the memory is only valid inside the closure scope. 

The problem surfaced only in release builds, because the optimization did not apply in debug builds.

## Solution

Refactored the code to process the buffer inside the withUnsafeBytes closure by copying the data into a [Int8] array. This ensures memory safety, improves readability, and prevents potential crashes or incorrect data caused by dangling pointers.